### PR TITLE
chore: migrate repo from awslabs to aws

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: 💬 General Question
-    url: https://github.com/awslabs/aws-crt-kotlin/discussions/categories/q-a
+    url: https://github.com/aws/aws-crt-kotlin/discussions/categories/q-a
     about: Please ask and answer questions as a discussion thread

--- a/.github/workflows/artifact-size-metrics.yml
+++ b/.github/workflows/artifact-size-metrics.yml
@@ -26,7 +26,7 @@ jobs:
           role-to-assume: ${{ secrets.CI_AWS_ROLE_ARN }}
           aws-region: us-west-2
       - name: Configure Gradle
-        uses: awslabs/aws-kotlin-repo-tools/.github/actions/configure-gradle@main
+        uses: aws/aws-kotlin-repo-tools/.github/actions/configure-gradle@main
       - name: Generate Artifact Size Metrics
         run: ./gradlew artifactSizeMetrics
       - name: Save Artifact Size Metrics
@@ -45,14 +45,14 @@ jobs:
           role-to-assume: ${{ secrets.CI_AWS_ROLE_ARN }}
           aws-region: us-west-2
       - name: Configure Gradle
-        uses: awslabs/aws-kotlin-repo-tools/.github/actions/configure-gradle@main
+        uses: aws/aws-kotlin-repo-tools/.github/actions/configure-gradle@main
       - name: Generate Artifact Size Metrics
         run: ./gradlew -Paws.kotlin.native=false artifactSizeMetrics
       - name: Analyze Artifact Size Metrics
         run: ./gradlew analyzeArtifactSizeMetrics
 
       - name: Show Results
-        uses: awslabs/aws-kotlin-repo-tools/.github/actions/artifact-size-metrics/show-results@main
+        uses: aws/aws-kotlin-repo-tools/.github/actions/artifact-size-metrics/show-results@main
 
       - name: Evaluate
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'acknowledge-artifact-size-increase') }}

--- a/.github/workflows/changelog-verification.yml
+++ b/.github/workflows/changelog-verification.yml
@@ -21,4 +21,4 @@ jobs:
           aws-region: us-west-2
 
       - name: Verify changelog
-        uses: awslabs/aws-kotlin-repo-tools/.github/actions/changelog-verification@main
+        uses: aws/aws-kotlin-repo-tools/.github/actions/changelog-verification@main

--- a/.github/workflows/kat-transform.yml
+++ b/.github/workflows/kat-transform.yml
@@ -36,7 +36,7 @@ jobs:
           aws-region: us-west-2
 
       - name: Setup kat
-        uses: awslabs/aws-kotlin-repo-tools/.github/actions/setup-kat@main
+        uses: aws/aws-kotlin-repo-tools/.github/actions/setup-kat@main
 
       - name: Configure JDK
         uses: actions/setup-java@v3
@@ -46,7 +46,7 @@ jobs:
           cache: 'gradle'
 
       - name: Configure Gradle
-        uses: awslabs/aws-kotlin-repo-tools/.github/actions/configure-gradle@main
+        uses: aws/aws-kotlin-repo-tools/.github/actions/configure-gradle@main
         with:
           working-directory: ./aws-crt-kotlin
 

--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Merge main
-        uses: awslabs/aws-kotlin-repo-tools/.github/actions/merge-main@main
+        uses: aws/aws-kotlin-repo-tools/.github/actions/merge-main@main
         with:
           ci-user-pat: ${{ secrets.CI_USER_PAT }}
           exempt-branches: # Add any if required

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*    @awslabs/aws-sdk-kotlin-sde
+*    @aws/aws-sdk-kotlin-team

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ of your request may disagree and ask that you add one anyway.
   "type": "feature",
   "description": "Add binding for CRT URL parsing",
   "issues": [
-    "awslabs/aws-crt-kotlin#12345"
+    "aws/aws-crt-kotlin#12345"
   ]
 }
 ```


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Migrate repository references from awslabs to aws organization following GitHub repository transfer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
