### PR TITLE
chore: add support for external PR CI

### DIFF
--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -1,0 +1,81 @@
+# Branch protection configuration
+
+This repo runs CI from two origins, and branch protection must cover both with a
+single required status context.
+
+## The one required status context
+
+Configure exactly **one** required status check on the protected branch:
+
+- `required`
+
+Both the privileged fork-PR entrypoint (`external-pr-ci.yml`) and the same-repo
+aggregate (`ci-required.yml`) publish a job named `required`, so a single
+branch-protection rule covers both origins.
+
+## Why only `required`
+
+Fork PRs run through the privileged entrypoint (`external-pr-ci.yml`), which
+calls the reusable workflows (`ci.yaml`, `changelog-verification.yml`,
+`kat-transform.yml`) as `workflow_call` jobs. Because they run as *called*
+workflows, every job context is **prefixed by the caller job name**. Fork-PR
+contexts therefore look like:
+
+- `ci / jvm (17)`  *(jvm/macos/windows run only on the unprivileged path — see below)*
+- `ci / linux`
+- `ci / linux-native (x64, al2)`
+- `ci / linux-native (x64, al2023)`
+- `ci / linux-native (x64, ubuntu-22.04)`
+- `ci / linux-native (arm64, al2)`
+- `ci / linux-native (arm64, al2023)`
+- `ci / linux-native (arm64, ubuntu-22.04)`
+- `ci / required` *(ci.yaml has no internal aggregate; the entrypoint's own `required` job is what gates)*
+- `changelog / changelog-verification`
+- `kat-transform / verify-transform`
+- `required`  *(the entrypoint aggregate — the one to require)*
+
+Same-repo PRs run the workflows directly via `pull_request`, producing
+**unprefixed** contexts:
+
+- `jvm (8)`, `jvm (11)`, `jvm (17)`, `jvm (21)`
+- `macos (...)`
+- `linux`
+- `linux-native (x64, al2)` … etc.
+- `windows`
+- `changelog-verification`
+- `verify-transform`
+- `required`  *(the same-repo aggregate from `ci-required.yml` — same name)*
+
+Notes on job behavior:
+
+- `jvm`, `macos`, and `windows` in `ci.yaml` carry
+  `if: ${{ github.event_name != 'workflow_call' }}`, so on the privileged
+  fork path they are **skipped** — they run only on the unprivileged same-repo
+  path (fork code needs no credentials for these, and they already pass on
+  forks). Their fork-PR contexts above are listed for completeness but are
+  skipped under `workflow_call`.
+- `linux` is the only credentialed job (`CI_AWS_ROLE_ARN` for the Docker image
+  build) and is **ungated**, so it runs on both paths.
+- `linux-native` **depends on `linux`** (`needs: linux`) and consumes its
+  `native-test-binaries` artifact. It has no checkout and no event guard, so it
+  runs whenever `linux` runs — including the privileged fork path.
+
+## Caveat
+
+Do **not** mark any prefixed (`ci / …`, `changelog / …`, `kat-transform / …`)
+or unprefixed individual context as "required". Each of those can be produced by
+only **one** origin — requiring one would block PRs from the other origin
+forever (the context would never appear). Only the single, same-named `required`
+aggregate is produced by both origins, so it is the only safe required context.
+
+## Limitation of `ci-required.yml`
+
+The same-repo aggregate (`ci-required.yml`) only *produces the `required`
+context name* on the same-repo path — it does **not** itself gate or depend on
+the individual same-repo checks. Those same-repo checks (`jvm`, `macos`,
+`linux`, `linux-native`, `windows`, `changelog-verification`,
+`verify-transform`) remain independently required by virtue of running on the
+same-repo `pull_request` path; if you want them enforced, they must be trusted
+via normal same-repo CI, not through this aggregate. The aggregate exists solely
+so that a single branch-protection rule named `required` is satisfiable from
+both origins.

--- a/.github/workflows/changelog-verification.yml
+++ b/.github/workflows/changelog-verification.yml
@@ -12,6 +12,15 @@ on:
       - '*-main'
   merge_group:
     types: [checks_requested]
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        required: false
+        default: ''
+    secrets:
+      CI_AWS_ROLE_ARN:
+        required: true
 
 jobs:
   changelog-verification:
@@ -26,3 +35,5 @@ jobs:
 
       - name: Verify changelog
         uses: aws/aws-kotlin-repo-tools/.github/actions/changelog-verification@main
+        with:
+          ref: ${{ inputs.ref }}

--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -5,6 +5,9 @@ on:
   merge_group:
     types: [checks_requested]
 
+permissions:
+  contents: read
+
 jobs:
   required:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -1,0 +1,13 @@
+name: CI Required (same-repo aggregate)
+
+on:
+  pull_request:
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  required:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate placeholder
+        run: echo "Same-repo aggregate required context satisfied."

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,15 @@ on:
   merge_group:
     types: [checks_requested]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        required: false
+        default: ''
+    secrets:
+      CI_AWS_ROLE_ARN:
+        required: true
 
 env:
   PACKAGE_NAME: aws-crt-kotlin
@@ -21,6 +30,7 @@ permissions:
 jobs:
   jvm:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'workflow_call' }}
     strategy:
       fail-fast: false
       matrix:
@@ -34,6 +44,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Configure JDK
         uses: actions/setup-java@v3
@@ -59,6 +71,7 @@ jobs:
   # macOS ARM images build and test for targets: jvm, macosArm64, iosSimulatorArm64, watchosSimulatorArm65, tvosSimulatorArm64
   # macos x64 images build and test for targets: jvm, macosX64, iosX64, tvosX64, watchosX64
   macos:
+    if: ${{ github.event_name != 'workflow_call' }}
     strategy:
       fail-fast: false
       matrix:
@@ -72,6 +85,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          ref: ${{ inputs.ref }}
       - name: Setup build environment
         uses: ./.github/actions/setup-build
       - name: Build and Test ${{ env.PACKAGE_NAME }}
@@ -96,6 +110,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          ref: ${{ inputs.ref }}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -171,10 +186,12 @@ jobs:
   # windows JVM & native
   windows:
     runs-on: windows-2022
+    if: ${{ github.event_name != 'workflow_call' }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          ref: ${{ inputs.ref }}
       - name: Set up MSYS2
         uses: msys2/setup-msys2@v2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ permissions:
 jobs:
   jvm:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'workflow_call' }}
+    if: ${{ github.event_name != 'pull_request_target' }}
     strategy:
       fail-fast: false
       matrix:
@@ -71,7 +71,7 @@ jobs:
   # macOS ARM images build and test for targets: jvm, macosArm64, iosSimulatorArm64, watchosSimulatorArm65, tvosSimulatorArm64
   # macos x64 images build and test for targets: jvm, macosX64, iosX64, tvosX64, watchosX64
   macos:
-    if: ${{ github.event_name != 'workflow_call' }}
+    if: ${{ github.event_name != 'pull_request_target' }}
     strategy:
       fail-fast: false
       matrix:
@@ -186,7 +186,7 @@ jobs:
   # windows JVM & native
   windows:
     runs-on: windows-2022
-    if: ${{ github.event_name != 'workflow_call' }}
+    if: ${{ github.event_name != 'pull_request_target' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/external-pr-ci.yml
+++ b/.github/workflows/external-pr-ci.yml
@@ -1,0 +1,77 @@
+name: External PR CI (privileged)
+
+on:
+  pull_request_target:
+    types: [labeled, synchronize]
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
+concurrency:
+  group: external-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      approved: ${{ steps.check.outputs.approved }}
+    steps:
+      - name: Revoke approval on new commits
+        if: ${{ github.event.action == 'synchronize' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr edit "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --remove-label safe-to-test || true
+
+      - name: Determine whether to run
+        id: check
+        run: |
+          if [ "${{ github.event.action }}" = "labeled" ] && \
+             [ "${{ github.event.label.name }}" = "safe-to-test" ] && \
+             [ "${{ github.event.pull_request.head.repo.fork }}" = "true" ]; then
+            echo "approved=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "approved=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  ci:
+    needs: gate
+    if: ${{ needs.gate.outputs.approved == 'true' }}
+    uses: ./.github/workflows/ci.yaml
+    secrets: inherit
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}
+
+  changelog:
+    needs: gate
+    if: ${{ needs.gate.outputs.approved == 'true' }}
+    uses: ./.github/workflows/changelog-verification.yml
+    secrets: inherit
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}
+
+  kat-transform:
+    needs: gate
+    if: ${{ needs.gate.outputs.approved == 'true' }}
+    uses: ./.github/workflows/kat-transform.yml
+    secrets: inherit
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}
+
+  required:
+    if: ${{ always() }}
+    needs: [ci, changelog, kat-transform]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate results
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]; then
+            echo "One or more required jobs failed or were cancelled."
+            exit 1
+          fi
+          echo "All required jobs succeeded."

--- a/.github/workflows/kat-transform.yml
+++ b/.github/workflows/kat-transform.yml
@@ -8,6 +8,15 @@ on:
       - '*-main'
   merge_group:
     types: [checks_requested]
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        required: false
+        default: ''
+    secrets:
+      CI_AWS_ROLE_ARN:
+        required: true
 
 # Allow one instance of this workflow per pull request, and cancel older runs when new changes are pushed
 concurrency:
@@ -30,6 +39,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: 'aws-crt-kotlin'
+          ref: ${{ inputs.ref }}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/kat-transform.yml
+++ b/.github/workflows/kat-transform.yml
@@ -20,7 +20,7 @@ on:
 
 # Allow one instance of this workflow per pull request, and cancel older runs when new changes are pushed
 concurrency:
-  group: kat-pr-${{ github.ref }}
+  group: kat-pr-${{ inputs.ref || github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
*Issue #, if available:*

(none)

*Description of changes:*

Add support for external PRs to successfully execute CI workflows after being approved by a maintainer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
